### PR TITLE
Fix for strange devhelp behavior launched from nonroot

### DIFF
--- a/debian/gbp.conf
+++ b/debian/gbp.conf
@@ -1,0 +1,9 @@
+[DEFAULT]
+# the default branch for upstream sources
+upstream-branch=upstream
+# the default branch for the debian patch
+debian-branch=master
+
+[buildpackage]
+# use separate dir for building
+export-dir  = ../build-area/


### PR DESCRIPTION
Hi.
I found a strange bug, trying to use this docs with Devhelp on Ubuntu (tested on 2 real computers with Kubuntu and Xubuntu). Seems that webkit2gtk from devhelp for some reason don't want to read html pages with XHTML DOCTYPE when launched from regular user or even from sudo, but works fine when launched from root directly. I can't find a real reason of this due to a very large source code of webkit and my low skills in debugging, so i made this walkaround, just changed cppreference output settings to change DOCTYPE to html. After that this all works for me on all my computers.

More info is here https://bugs.launchpad.net/ubuntu/+source/cppreference-doc/+bug/1668085
Also the same thing was detecded by somebody in archlinux https://aur.archlinux.org/packages/cppreference-devhelp/
PPA with modified packages:
https://launchpad.net/~sagrer/+archive/ubuntu/cppreference-doc

Also i added gbp config to my repository to make gbp using some more easy, changed upstream link to correct commit, added a tag to last upstream and added a branch for autogeneration of patches by gbp pq, may be this all can be added to main repository too, i think this all makes things more easy :).