### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cppreference-doc (20170409-3) UNRELEASED; urgency=medium
+
+  * Update renamed lintian tag names in lintian overrides.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Apr 2020 16:05:54 +0000
+
 cppreference-doc (20170409-2) unstable; urgency=low
 
   * Override source-is-missing for files that have their real source in the

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 cppreference-doc (20170409-3) UNRELEASED; urgency=medium
 
   * Update renamed lintian tag names in lintian overrides.
+  * Update standards version to 4.5.0, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Apr 2020 16:05:54 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper-compat (= 12),
                python3,
                python3-lxml,
                qttools5-dev-tools
-Standards-Version: 4.4.1
+Standards-Version: 4.5.0
 Vcs-Browser: https://github.com/p12tic/cppreference-doc-debian
 Vcs-Git: https://github.com/p12tic/cppreference-doc-debian.git
 Homepage: https://en.cppreference.com/w/Cppreference:Archives

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -10,4 +10,4 @@ cppreference-doc source: license-problem-gfdl-invariants reference/cppreference-
 cppreference-doc source: source-is-missing reference/en.cppreference.com/*
 
 # The actual source is in reference/cppreference-export-*.
-cppreference-doc source: insane-line-length-in-source-file reference/en.cppreference.com/*
+cppreference-doc source: very-long-line-length-in-source-file reference/en.cppreference.com/*


### PR DESCRIPTION
Fix some issues reported by lintian
* Update renamed lintian tag names in lintian overrides. ([renamed-tag](https://lintian.debian.org/tags/renamed-tag.html))
* Update standards version to 4.5.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/cppreference-doc/579fd751-85e5-4a60-8560-568ab71e0d64.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/579fd751-85e5-4a60-8560-568ab71e0d64/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/579fd751-85e5-4a60-8560-568ab71e0d64/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/579fd751-85e5-4a60-8560-568ab71e0d64/diffoscope)).
