### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper-compat (= 13),
                python3,
                python3-lxml,
                qttools5-dev-tools
-Standards-Version: 4.4.1
+Standards-Version: 4.5.1
 Vcs-Browser: https://github.com/p12tic/cppreference-doc-debian
 Vcs-Git: https://github.com/p12tic/cppreference-doc-debian.git
 Homepage: https://en.cppreference.com/w/Cppreference:Archives

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: cppreference-doc
 Maintainer: Povilas Kanapickas <povilas@radix.lt>
 Section: doc
 Priority: optional
-Build-Depends: debhelper-compat (= 12),
+Build-Depends: debhelper-compat (= 13),
                xsltproc,
                python3,
                python3-lxml,

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -10,4 +10,4 @@ cppreference-doc source: license-problem-gfdl-invariants reference/cppreference-
 cppreference-doc source: source-is-missing reference/en.cppreference.com/*
 
 # The actual source is in reference/cppreference-export-*.
-cppreference-doc source: insane-line-length-in-source-file reference/en.cppreference.com/*
+cppreference-doc source: very-long-line-length-in-source-file reference/en.cppreference.com/*


### PR DESCRIPTION
Fix some issues reported by lintian

* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))

* Update renamed lintian tag names in lintian overrides. ([renamed-tag](https://lintian.debian.org/tags/renamed-tag))

* Update standards version to 4.5.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/cppreference-doc/e705defd-9677-4d8f-8db6-2ae40f5948fc.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/share/doc-base/cppreference-doc-en-html.cppreference-doc-en-c
    -rw-r--r--  root/root   /usr/share/doc-base/cppreference-doc-en-html.cppreference-doc-en-cpp
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/share/doc-base/cppreference-doc-en-c
    -rw-r--r--  root/root   /usr/share/doc-base/cppreference-doc-en-cpp

No differences were encountered between the control files of package \*\*cppreference-doc-en-html\*\*

No differences were encountered between the control files of package \*\*cppreference-doc-en-qch\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/e705defd-9677-4d8f-8db6-2ae40f5948fc/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/e705defd-9677-4d8f-8db6-2ae40f5948fc/diffoscope)).
