### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper-compat (= 13),
                python3,
                python3-lxml,
                qttools5-dev-tools
-Standards-Version: 4.5.1
+Standards-Version: 4.6.2
 Vcs-Browser: https://github.com/p12tic/cppreference-doc-debian
 Vcs-Git: https://github.com/p12tic/cppreference-doc-debian.git
 Homepage: https://en.cppreference.com/w/Cppreference:Archives

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -7,7 +7,7 @@ cppreference-doc source: license-problem-gfdl-invariants reference/cppreference-
 # The source package includes both a downloaded copy of the cppreference.com
 # wiki and the copy of the underlying sources of the wiki. The sources of the wiki
 # are placed at reference/cppreference-export-*
-cppreference-doc source: source-is-missing reference/en.cppreference.com/*
+cppreference-doc source: source-is-missing [reference/en.cppreference.com/*]
 
 # The actual source is in reference/cppreference-export-*.
 cppreference-doc source: very-long-line-length-in-source-file reference/en.cppreference.com/*


### PR DESCRIPTION
Fix some issues reported by lintian

* Update lintian override info format in d/source/lintian-overrides on line 10. ([mismatched-override](https://lintian.debian.org/tags/mismatched-override))
* Update standards version to 4.6.2, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

These changes have no impact on the [binary debdiff](https://janitor.debian.net/api/run/fc045b47-ca31-428e-9ea7-1cc73a8de5fc/debdiff?filter_boring=1).

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/fc045b47-ca31-428e-9ea7-1cc73a8de5fc/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/fc045b47-ca31-428e-9ea7-1cc73a8de5fc/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/lintian-fixes/pkg/cppreference-doc/fc045b47-ca31-428e-9ea7-1cc73a8de5fc.